### PR TITLE
Add config translations

### DIFF
--- a/onedrive-backup/translations/de.yaml
+++ b/onedrive-backup/translations/de.yaml
@@ -1,0 +1,40 @@
+configuration:
+  local_backup_num_to_keep:
+    name: Anzahl der lokalen Sicherungen
+    description: Die maximale Anzahl von Sicherungen, die lokal im Home Assistant gespeichert werden sollen
+  onedrive_backup_num_to_keep:
+    name: Anzahl der Sicherungen in OneDrive
+    description: Die maximale Anzahl der in OneDrive zu speichernden Sicherungen
+  backup_interval_days:
+    name: Sicherungsintervall (Tage)
+    description: Die Häufigkeit der Sicherungserstellung in Tagen. Um eine untertägige Ausführung festzulegen, können Sie eine Zahl zwischen 0 und 1 verwenden. Wenn der Wert hier z. B. auf 0,5 gesetzt wird, erfolgt die Sicherung alle 12 Stunden. Sie sollten es vermeiden, einen Wert unter 0,083 (~2 Stunden) zu verwenden, da das derzeitige Mindestintervall für die Synchronisierung einmal pro Stunde beträgt.
+  backup_passwd:
+    name: Sicherungskennwort
+    description: Das Kennwort, mit dem die erstellten und auf OneDrive hochgeladenen Sicherungen geschützt werden sollen.
+  backup_name:
+    name: Name der Sicherung
+    description: Name, der für die vom Add-on erstellten Sicherungen verwendet werden soll.
+  notify_on_error:
+    name: Benachrichtigung im Fehlerfall
+    description: Aktiviert dauerhafte Benachrichtigungen im Home Assistant, um über Fehler bei der Datensicherung zu informieren.
+  recovery_mode:
+    name: Wiederherstellungsmodus
+    description: Wenn diese Einstellung aktiviert ist, führt das Add-on keine Sicherungen durch und der Synchronisierungsmodus arbeitet umgekehrt, von OneDrive zu Home Assistant. Dies respektiert immer noch die eingestellte maximale Anzahl lokaler Sicherungen und versucht, die neuesten Sicherungen, die in OneDrive vorhanden sind, zu synchronisieren, während es unter dem eingestellten Limit bleibt.
+  hass_api_timeout_minutes:
+    name: Hass api timeout (Minuten)
+    description: Hier können Sie die beim Aufruf der Home Assistant-APIs verwendete Zeitüberschreitung einstellen.
+  exclude_media_folder:
+    name: Medienordner ausschließen
+    description: Wenn diese Option aktiviert ist, wird eine Teilsicherung ohne den Ordner "media" erstellt.
+  exclude_ssl_folder:
+    name: ssl-Ordner ausschließen
+    description: Wenn diese Option aktiviert ist, wird eine Teilsicherung ohne den Ordner "ssl" erstellt.
+  exclude_share_folder:
+    name: Freigabeordner ausschließen
+    description: Wenn diese Option aktiviert ist, wird eine Teilsicherung ohne den Ordner "share" erstellt.
+  exclude_local_addons_folder:
+    name: Lokalen Addons-Ordner ausschließen
+    description: Wenn diese Option aktiviert ist, wird eine Teilsicherung ohne den Ordner "addons/local" erstellt.
+  backup_allowed_hours:
+    name: Zulässige Stunden
+    description: Hier kann ein Stundenbereich von 0 bis 23 angegeben werden, in dem nur während dieser Stunden Backups durchgeführt werden. Wenn eine Sicherung erforderlich ist, wird sie im ersten zulässigen Zeitfenster innerhalb der festgelegten Stunden durchgeführt. Das Format ist ein oder mehrere Bereiche, die durch ein Komma getrennt sind. Ein Bereich wird durch einen Bindestrich angegeben.

--- a/onedrive-backup/translations/en.yaml
+++ b/onedrive-backup/translations/en.yaml
@@ -1,0 +1,40 @@
+configuration:
+  local_backup_num_to_keep:
+    name: Number of local backups
+    description: The maximum amount of backups to keep locally in Home Assistant
+  onedrive_backup_num_to_keep:
+    name: Number of OneDrive backups
+    description: The maximum amount of backups to keep in OneDrive
+  backup_interval_days:
+    name: Backup interval (days)
+    description: The backup creation frequency in days. For setting a sub-day frequency you can use a number between 0 and 1, so for example if the value here is set to 0.5, the backup frequency will occur every 12 hours. You should avoid using a value less than 0.083 (~2 hours) as the current enforced minimum sync interval is once an hour.
+  backup_passwd:
+    name: Backup password
+    description: The password to use to protect the backups created and uploaded to OneDrive.
+  backup_name:
+    name: Backup name
+    description: Name to use for the backups created by the add-on.
+  notify_on_error:
+    name: Notify on error
+    description: Enables persistent notifications in Home Assistant to notify of backup failures.
+  recovery_mode:
+    name: Recovery mode
+    description: When this settings is toggled on, the add-on will not perform any backups and sync mode will reverse from OneDrive back to Home Assistant. This will still respect the maximum local backups set and will try to sync back the latest backups that exist in OneDrive while remaining under the set limit.
+  hass_api_timeout_minutes:
+    name: Hass api timeout (minutes)
+    description: This allows you to set the timeout configured when calling the Home Assistant APIs.
+  exclude_media_folder:
+    name: Exclude media folder
+    description: When enabled, a partial backup will be created without the media folder
+  exclude_ssl_folder:
+    name: Exclude ssl folder
+    description: When enabled, a partial backup will be created without the ssl folder
+  exclude_share_folder:
+    name: Exclude share folder
+    description: When enabled, a partial backup will be created without the share folder
+  exclude_local_addons_folder:
+    name: Exclude local addons folder
+    description: When enabled, a partial backup will be created without the addons/local folder
+  backup_allowed_hours:
+    name: Allowed hours
+    description: This accepts a range of hours from 0 to 23 for which only during these hours will backups be performed. If a backup is required it will be performed at the first window allowed in the defined hours. The format of this is one or more ranges seperated by a comma. A range is specified by a dash.


### PR DESCRIPTION
Hi lavinir,

first: I'm using this addon since you've posted it on reddit. It its working flawlessly on my raspberry pi since then.

With this PR I want to add translations to the configuration. Doing it this way the user will have natural names for every option instead of the technical names including the description you gave on the readme page.
As a native german speaker I've also added a german translation. May be this inspires anyone to add his or her own language.

Here is a preview of what the settings page will look like:
![image](https://user-images.githubusercontent.com/2649987/206894569-190fbe49-eb95-48be-8be9-a964231e204a.png)
